### PR TITLE
fix(olHelpers.js): use HTTPS Mapbox URL

### DIFF
--- a/src/services/olHelpers.js
+++ b/src/services/olHelpers.js
@@ -200,7 +200,7 @@ angular.module('openlayers-directive').factory('olHelpers', function($q, $log, $
                     $log.error('[AngularJS - Openlayers] - MapBox layer requires the map id and the access token');
                     return;
                 }
-                url = 'http://api.tiles.mapbox.com/v4/' + source.mapId + '/{z}/{x}/{y}.png?access_token=' +
+                url = 'https://api.tiles.mapbox.com/v4/' + source.mapId + '/{z}/{x}/{y}.png?access_token=' +
                     source.accessToken;
 
                 var pixelRatio = window.devicePixelRatio;


### PR DESCRIPTION
This addresses issue #337. It is a one-character change, changing the protocol from http to https.